### PR TITLE
Open GitHub link with external browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,6 @@ Running `yarn tauri build`, AppImage, deb and rpm in `src-tauri/target/release/b
 yarn tauri build
 ```
 
-## Launch as Web application
-
-It can also be built as a typical static single-page application. 
-It can be distributed using a web server such as Apache or Nginx or a tool such as [vercel/serve](https://github.com/vercel/serve).
-
-```sh
-npm install --global serve
-serve --single build --listen 8080
-```
-
-
 ## Author
 
 [sheepla](https://github.com/sheepla)

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -12,7 +12,7 @@ import {
   Divider,
 } from "@mui/material";
 import GitHubIcon from "@mui/icons-material/GitHub";
-import { open as browserOpen} from "@tauri-apps/api/shell";
+import { open as browserOpen } from "@tauri-apps/api/shell";
 
 const AboutDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
   return (

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -12,6 +12,7 @@ import {
   Divider,
 } from "@mui/material";
 import GitHubIcon from "@mui/icons-material/GitHub";
+import { open as browserOpen} from "@tauri-apps/api/shell";
 
 const AboutDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
   return (
@@ -51,7 +52,9 @@ const AboutDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, o
               <Button
                 variant="contained"
                 startIcon={<GitHubIcon />}
-                href="https://github.com/sheepla/csv-grid-viewer"
+                onClick={async () => {
+                  await browserOpen("https://github.com/sheepla/csv-grid-viewer");
+                }}
               >
                 See GitHub Repository
               </Button>


### PR DESCRIPTION
This pull request is implemented #8.

Implement open github link with external browser and update README†.
† Now that we use Tauri's API, we can no longer publish as SPA.